### PR TITLE
fixes the issue of godbolt.nvim on Windows platforms

### DIFF
--- a/lua/godbolt/cmd.lua
+++ b/lua/godbolt/cmd.lua
@@ -4,7 +4,7 @@ local function build_cmd(compiler, text, options, exec_asm_3f)
   local file = io.open(string.format("godbolt_request_%s.json", exec_asm_3f), "w")
   file:write(json)
   io.close(file)
-  return string.format(("curl %s/api/compiler/'%s'/compile" .. " --data-binary @godbolt_request_%s.json" .. " --header 'Accept: application/json'" .. " --header 'Content-Type: application/json'" .. " --output godbolt_response_%s.json"), config.url, compiler, exec_asm_3f, exec_asm_3f)
+  return string.format(("curl %s/api/compiler/%s/compile" .. " --data-binary @godbolt_request_%s.json" .. " --header 'Accept: application/json'" .. " --header 'Content-Type: application/json'" .. " --output godbolt_response_%s.json"), config.url, compiler, exec_asm_3f, exec_asm_3f)
 end
 local function godbolt(begin, _end, reuse_3f, compiler)
   local pre_display = (require("godbolt.assembly"))["pre-display"]

--- a/lua/godbolt/cmd.lua
+++ b/lua/godbolt/cmd.lua
@@ -5,8 +5,8 @@ local function build_cmd(compiler, text, options, exec_asm_3f)
   file:write(json)
   io.close(file)
   local request = string.format(("curl %s/api/compiler/%s/compile" .. " --data-binary @godbolt_request_%s.json" .. " --header 'Accept: application/json'" .. " --header 'Content-Type: application/json'" .. " --output godbolt_response_%s.json"), config.url, compiler, exec_asm_3f, exec_asm_3f)
-  if vim.loop.os_uname().sysname == 'Windows_NT' then
-    request = request:gsub('\'', '"')
+  if vim.loop.os_uname().sysname == "Windows_NT" then
+    request = request:gsub("'", "\"")
   end
   return request
 end

--- a/lua/godbolt/cmd.lua
+++ b/lua/godbolt/cmd.lua
@@ -4,7 +4,11 @@ local function build_cmd(compiler, text, options, exec_asm_3f)
   local file = io.open(string.format("godbolt_request_%s.json", exec_asm_3f), "w")
   file:write(json)
   io.close(file)
-  return string.format(("curl %s/api/compiler/%s/compile" .. " --data-binary @godbolt_request_%s.json" .. " --header 'Accept: application/json'" .. " --header 'Content-Type: application/json'" .. " --output godbolt_response_%s.json"), config.url, compiler, exec_asm_3f, exec_asm_3f)
+  local request = string.format(("curl %s/api/compiler/%s/compile" .. " --data-binary @godbolt_request_%s.json" .. " --header 'Accept: application/json'" .. " --header 'Content-Type: application/json'" .. " --output godbolt_response_%s.json"), config.url, compiler, exec_asm_3f, exec_asm_3f)
+  if vim.loop.os_uname().sysname == 'Windows_NT' then
+    request = request:gsub('\'', '"')
+  end
+  return request
 end
 local function godbolt(begin, _end, reuse_3f, compiler)
   local pre_display = (require("godbolt.assembly"))["pre-display"]


### PR DESCRIPTION
Hello,

This PR fixes the issue of godbolt.nvim on Windows platforms.

- `godolt.nvim` no longer requires single quotes to mark compiler names.  (https://github.com/compiler-explorer/compiler-explorer/blob/main/docs/API.md#post-apicompilercompiler-idcompile---perform-a-compilation-1).
-  Windows prefers to use double quotation marks for command options. 